### PR TITLE
fix: surface silent errors in pagemap, numeric parser, and SQLite export

### DIFF
--- a/engine/convert.go
+++ b/engine/convert.go
@@ -152,7 +152,7 @@ func ConvertValue(data []byte, typeID uint16) (any, error) {
 // Format: [precision u8][scale u8][sign u8 (1=pos,0=neg)][16-byte uint128 LE]
 func parseNumeric(data []byte) (string, error) {
 	if len(data) != 19 {
-		return fmt.Sprintf("%x", data), nil
+		return "", fmt.Errorf("numeric: expected 19 bytes, got %d", len(data))
 	}
 
 	scale := int(data[1])

--- a/engine/integration_test.go
+++ b/engine/integration_test.go
@@ -209,10 +209,14 @@ func TestControlLayerQueries(t *testing.T) {
 	}
 	defer sdfDB.Close()
 
-	exportedDB, err := engine.ExportToSQLite(sdfDB)
+	exportRes, err := engine.ExportToSQLite(sdfDB)
 	if err != nil {
 		t.Fatalf("ExportToSQLite: %v", err)
 	}
+	for _, w := range exportRes.Warnings {
+		t.Logf("export warning: %v", w)
+	}
+	exportedDB := exportRes.DB
 	defer exportedDB.Close()
 
 	refDB, err := sql.Open("sqlite", "../data/Depropanizer.db")

--- a/engine/sqlite.go
+++ b/engine/sqlite.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/jamestjat/sqlce/format"
@@ -11,23 +10,35 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// ExportResult holds the SQLite DB and any non-fatal warnings from export.
+type ExportResult struct {
+	DB       *sql.DB
+	Warnings []error
+}
+
 // ExportToSQLite loads all tables from the SDF database into an in-memory
-// SQLite database and returns it. The caller must close the returned DB.
-func ExportToSQLite(db *Database) (*sql.DB, error) {
+// SQLite database and returns it. Non-fatal per-table errors are collected
+// in ExportResult.Warnings. The caller must close the returned DB.
+func ExportToSQLite(db *Database) (*ExportResult, error) {
 	sqliteDB, err := sql.Open("sqlite", "file::memory:?cache=shared")
 	if err != nil {
 		return nil, fmt.Errorf("creating in-memory SQLite: %w", err)
 	}
 
+	res := &ExportResult{DB: sqliteDB}
+	warn := func(table string, msg string, err error) {
+		res.Warnings = append(res.Warnings, fmt.Errorf("export %s: %s: %w", table, msg, err))
+	}
+
 	for _, name := range db.Tables() {
 		tbl, err := db.Table(name)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  export skip %s: %v\n", name, err)
+			warn(name, "open", err)
 			continue
 		}
 		result, err := tbl.Scan()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  export skip %s: scan: %v\n", name, err)
+			warn(name, "scan", err)
 			continue
 		}
 		cols := tbl.Columns()
@@ -37,7 +48,7 @@ func ExportToSQLite(db *Database) (*sql.DB, error) {
 
 		createSQL := BuildCreateTable(name, cols)
 		if _, err := sqliteDB.Exec(createSQL); err != nil {
-			fmt.Fprintf(os.Stderr, "  export skip %s: create table: %v\n", name, err)
+			warn(name, "create table", err)
 			continue
 		}
 		if len(result.Rows) == 0 {
@@ -52,13 +63,13 @@ func ExportToSQLite(db *Database) (*sql.DB, error) {
 
 		tx, err := sqliteDB.Begin()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  export skip %s: begin: %v\n", name, err)
+			warn(name, "begin", err)
 			continue
 		}
 		stmt, err := tx.Prepare(insertSQL)
 		if err != nil {
 			tx.Rollback()
-			fmt.Fprintf(os.Stderr, "  export skip %s: prepare: %v\n", name, err)
+			warn(name, "prepare", err)
 			continue
 		}
 		var execErr error
@@ -77,15 +88,15 @@ func ExportToSQLite(db *Database) (*sql.DB, error) {
 		stmt.Close()
 		if execErr != nil {
 			tx.Rollback()
-			fmt.Fprintf(os.Stderr, "  export skip %s: insert: %v\n", name, execErr)
+			warn(name, "insert", execErr)
 			continue
 		}
 		if err := tx.Commit(); err != nil {
-			fmt.Fprintf(os.Stderr, "  export skip %s: commit: %v\n", name, err)
+			warn(name, "commit", err)
 		}
 	}
 
-	return sqliteDB, nil
+	return res, nil
 }
 
 func BuildCreateTable(name string, cols []format.ColumnDef) string {

--- a/format/pagemap.go
+++ b/format/pagemap.go
@@ -1,6 +1,9 @@
 package format
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 const (
 	offsetPage1Addr = 0x2C
@@ -13,7 +16,8 @@ const (
 )
 
 type PageMapping struct {
-	mapping map[int]int
+	mapping  map[int]int
+	Warnings []error
 }
 
 func BuildPageMapping(pr *PageReader) (*PageMapping, error) {
@@ -45,6 +49,7 @@ func BuildPageMapping(pr *PageReader) (*PageMapping, error) {
 
 		mapB, err := pr.ReadPage(addr)
 		if err != nil {
+			pm.Warnings = append(pm.Warnings, fmt.Errorf("MapB slot %d (page %d): %w", i, addr, err))
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- **pagemap**: MapB read failures now collected as `PageMapping.Warnings` instead of silently `continue`-ing (up to 1528 lost mappings per dropped chunk)
- **parseNumeric**: returns error for unexpected data length instead of injecting raw hex strings with nil error
- **ExportToSQLite**: returns `ExportResult{DB, Warnings}` instead of `fmt.Fprintf(os.Stderr, ...)` — embeddable as a library

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Verify `ExportResult.Warnings` surfaces skip reasons in downstream consumers
- [ ] Confirm no callers outside this repo depend on the old `(*sql.DB, error)` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)