### PR TITLE
fix: escape SQL identifiers in SQLite export

### DIFF
--- a/cmd/sdfutil/main.go
+++ b/cmd/sdfutil/main.go
@@ -397,7 +397,7 @@ func cmdExportSQLite(sdfPath, outputPath string) {
 		for i := range placeholders {
 			placeholders[i] = "?"
 		}
-		insertSQL := fmt.Sprintf(`INSERT INTO "%s" VALUES (%s)`, name, strings.Join(placeholders, ","))
+		insertSQL := fmt.Sprintf(`INSERT INTO "%s" VALUES (%s)`, engine.EscapeIdentifier(name), strings.Join(placeholders, ","))
 
 		tx, err := sqliteDB.Begin()
 		if err != nil {

--- a/engine/sqlite.go
+++ b/engine/sqlite.go
@@ -59,7 +59,7 @@ func ExportToSQLite(db *Database) (*ExportResult, error) {
 		for i := range placeholders {
 			placeholders[i] = "?"
 		}
-		insertSQL := fmt.Sprintf(`INSERT INTO "%s" VALUES (%s)`, name, strings.Join(placeholders, ","))
+		insertSQL := fmt.Sprintf(`INSERT INTO "%s" VALUES (%s)`, EscapeIdentifier(name), strings.Join(placeholders, ","))
 
 		tx, err := sqliteDB.Begin()
 		if err != nil {
@@ -99,13 +99,19 @@ func ExportToSQLite(db *Database) (*ExportResult, error) {
 	return res, nil
 }
 
+// EscapeIdentifier doubles any double-quote characters in s so it can be
+// safely used inside a "quoted" SQL identifier.
+func EscapeIdentifier(s string) string {
+	return strings.ReplaceAll(s, `"`, `""`)
+}
+
 func BuildCreateTable(name string, cols []format.ColumnDef) string {
 	var parts []string
 	for _, col := range cols {
 		sqlType := ceTypeToSQLite(col.TypeID)
-		parts = append(parts, fmt.Sprintf(`"%s" %s`, col.Name, sqlType))
+		parts = append(parts, fmt.Sprintf(`"%s" %s`, EscapeIdentifier(col.Name), sqlType))
 	}
-	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s" (%s)`, name, strings.Join(parts, ", "))
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s" (%s)`, EscapeIdentifier(name), strings.Join(parts, ", "))
 }
 
 func ceTypeToSQLite(typeID uint16) string {


### PR DESCRIPTION
## Summary
- Crafted SDF files with `"` in table/column names could inject arbitrary SQL during SQLite export (via `modernc.org/sqlite` multi-statement `Exec`)
- Added `EscapeIdentifier()` that doubles `"` → `""` per SQL standard
- Applied at all 4 identifier interpolation sites in `engine/sqlite.go` and `cmd/sdfutil/main.go`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `sdfutil export --format sqlite <sdf> <out.db>` produces correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)