### PR TITLE
Skip continuation slots in parsePageRecordsFollow; drop dead helper

### DIFF
--- a/format/catalog.go
+++ b/format/catalog.go
@@ -425,18 +425,6 @@ func readDataPageSlotAt(page []byte, rawIdx int) dataSlot {
 	return all[rawIdx]
 }
 
-// readDataPageEntries returns just entry data (for backward compat with record.go).
-func readDataPageEntries(page []byte) [][]byte {
-	slots := readDataPageSlots(page)
-	entries := make([][]byte, 0, len(slots))
-	for _, s := range slots {
-		if s.flags&1 == 0 {
-			entries = append(entries, s.data)
-		}
-	}
-	return entries
-}
-
 // followChunks reassembles a multi-slot record by following nextChunk
 // pointers. The pointer format is:
 //

--- a/format/record.go
+++ b/format/record.go
@@ -400,7 +400,10 @@ func parsePageRecordsFollow(page []byte, columns []ColumnDef, pr *PageReader, pm
 	slots := readDataPageSlots(page)
 	for _, slot := range slots {
 		if slot.flags&1 != 0 {
-			continue
+			continue // free/empty
+		}
+		if slot.flags&2 == 0 {
+			continue // continuation slot, reached via followChunks
 		}
 		entry := slot.data
 		if len(entry) < 8 {


### PR DESCRIPTION
Follow-up hardening for the area fixed in 932e93e (nextChunk / multi-slot record reassembly).

## What changed

- `parsePageRecordsFollow` now explicitly skips continuation slots via `flags&2 == 0`, matching the catalog iteration pattern in `ReadCatalog`. Previously it only filtered empty slots (`flags&1`) and relied on `entryColCount != colCount` to exclude continuations.
- Removed `readDataPageEntries` — no callers, and it carried the same missing flag check.

## Why

Continuation slots do not carry a start-of-record header. Without the `flags&2` check, a continuation whose bytes `[4:8]` coincidentally matched the table's column count would be treated as a new record: its first 4 bytes chased as a `nextChunk` pointer, and the resulting bytes fed to `parseOneRecord`. Low probability on any given table, but silent data corruption rather than a clean failure.

The catalog iteration (`format/catalog.go:163-167`) has always had both checks; this brings the user-table path in line.

## Test plan

- [x] `go build ./...`
- [x] `go test ./format/... ./engine/...` — all pass (includes `TestFollowChunks_RawSlotIndex` from 932e93e)

Closes #11
Closes #12